### PR TITLE
Parquet cache

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -147,7 +147,7 @@ end
 
 -- Get preview cache path
 local function get_cache_path(job, mode)
-	local cache_version = 1
+	local cache_version = 2
 	local skip = job.skip
 	job.skip = 1000000 + cache_version
 	local base = ya.file_cache(job)

--- a/main.lua
+++ b/main.lua
@@ -8,7 +8,7 @@ local M = {}
 
 local function log_timing(file, mode, label, duration)
 	local home = os.getenv("HOME") or "/tmp"
-	local log_path = "/Users/wylie/Desktop/Projects/duckdb.yazi_timings/duckdb-timings-db.csv"
+	local log_path = "/Users/wylie/Desktop/Projects/duckdb.yazi_timings/duckdb-timings-parquet.csv"
 	local exists = fs.cha(Url(log_path))
 
 	local row = string.format("%s,%s,%s,%.6f\n", file, mode, label, duration)
@@ -158,14 +158,15 @@ local function get_cache_path(job, mode)
 	return Url(tostring(base) .. "_" .. mode .. ".parquet")
 end
 
+local function is_duckdb_database(path)
+	local name = path:name() or ""
+	return name:match("%.duckdb$") or name:match("%.db$")
+end
+
 -- Run queries.
 local function run_query(job, query, target)
 	local args = {}
-	if target ~= job.file.url then
-		table.insert(args, tostring(target))
-	end
-	local name = job.file.url:name() or ""
-	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
+	if is_duckdb_database(target) then
 		table.insert(args, "-readonly")
 		table.insert(args, tostring(target))
 	end
@@ -186,17 +187,11 @@ local function run_query(job, query, target)
 end
 
 local function run_query_ascii_preview_mac(job, query, target)
-	local db_path = (target ~= job.file.url) and tostring(target) or ""
-
 	local width = math.max((job.area and job.area.w * 3 or 80), 80)
 	local height = math.max((job.area and job.area.h or 25), 25)
 
 	local args = { "-q", "/dev/null", "duckdb" }
-	if db_path ~= "" then
-		table.insert(args, db_path)
-	end
-	local name = job.file.url:name() or ""
-	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
+	if is_duckdb_database(target) then
 		table.insert(args, "-readonly")
 		table.insert(args, tostring(target))
 	end
@@ -241,11 +236,6 @@ local function create_cache(job, mode, path)
 			run_query(job, string.format("COPY (%s) TO '%s' (FORMAT 'parquet');", sql, tostring(path)), job.file.url)
 		return out ~= nil
 	end)
-end
-
-local function is_duckdb_database(path)
-	local name = path:name() or ""
-	return name:match("%.duckdb$") or name:match("%.db$")
 end
 
 local function generate_peek_query(target, job, limit, offset)


### PR DESCRIPTION
Changes cache and preview systems to use parquet files instead of duckdb databases as the cache. File size is much smaller and performance actually slightly improves which is a surprise.

File idenfication logic and SQL statements are adjusted accordingly.