### PR TITLE
Changes cache system to use parquet files instead of duckdb files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,40 @@
 # duckdb.yazi
 
-[duckdb](https://github.com/duckdb/duckdb) now in [yazi](https://github.com/sxyazi/yazi).
+**Uses  [duckdb](https://github.com/duckdb/duckdb) to quickly preview and summarize data files in [yazi](https://github.com/sxyazi/yazi)!**
 
-<img width="1710" alt="Screenshot 2025-03-22 at 18 00 06" src="https://github.com/user-attachments/assets/db09fff9-2db1-4273-9ddf-34d0bf087967" />
+<https://github.com/user-attachments/assets/d4a4e944-4119-4197-8e10-195520f364be>
+
+## What does it do?
+
+This plugin previews your data files in yazi using DuckDB, with two available view modes:
+
+- Standard mode (default): Displays the file as a table
+- Summarized mode: Uses DuckDB's summarize function, enhanced with custom formatting for readability
+- Scroll rows using J and K
+- Change modes by pressing K when at the top of a file
+
+Supported file types:
+
+- .csv  
+- .json  
+- .parquet  
+- .tsv  
+
+## New Features
+
+### Default preview mode is now "summarized". But can be changed by creating an init.lua file in your config/yazi directory. Details below
+
+- #### Preview mode can be toggled within yazi
+
+- #### Press "K" at the top of the file to toggle between "standard" and "summarized."
+
+- #### Preview mode is remembered on a per session basis, rather than per file. So if you toggle to standard, it will stay as standard in that session until toggled again
+
+### Performance improvements through caching
+
+- #### "Standard" and "summarized" views are cached upon first load, improving scrolling performance
+
+- #### Note that on entering a directory you haven't entered before (or one containing files that have been changed) cacheing is triggered. Until cache's are generated, summarized mode may take a longer to show as it will be run on the original file, and scrolling other files during this time (especially large ones) can slow things even further as new queries on the file will be competing with cache queries. Instead it is worth waiting until the caches load (displayed in bottom right corner) or switching to standard view during these first few seconds. This will be most apparent on large, non-parquet files
 
 ## Installation
 
@@ -12,20 +44,25 @@ ya pack -a wylie102/duckdb
 
 and add to your yazi.toml:
 
-[plugin]  
-prepend_previewers = [  
-  { mime = "text/csv", run = "duckdb" },  
-  { name = "*.tsv", run = "duckdb" },  
-  { name = "*.json", run = "duckdb" },  
-  { name = "*.parquet", run = "duckdb" },  
-]
+    [plugin]  
+    prepend_previewers = [  
+      { name = "*.csv", run = "duckdb" },  
+      { name = "*.tsv", run = "duckdb" },  
+      { name = "*.json", run = "duckdb" },  
+      { name = "*.parquet", run = "duckdb" },  
+    ]
 
-prepend_preloaders = [  
-  { mime = "text/csv", run = "duckdb", multi = false },  
-  { name = "*.tsv", run = "duckdb", multi = false },  
-  { name = "*.json", run = "duckdb", multi = false },  
-  { name = "*.parquet", run = "duckdb", multi = false },  
-]
+    prepend_preloaders = [  
+      { name = "*.csv", run = "duckdb", multi = false },  
+      { name = "*.tsv", run = "duckdb", multi = false },  
+      { name = "*.json", run = "duckdb", multi = false },  
+      { name = "*.parquet", run = "duckdb", multi = false },  
+    ]
+
+If you want to change the default view then create an init.lua file in your yazi folder (where your plugin folder and yazi.toml file live. Add the following:
+
+    -- duckdb plugin
+    require("duckdb"):setup({ mode = "standard" })
 
 ### Yazi
 
@@ -40,37 +77,18 @@ prepend_preloaders = [
 Use with a larger preview window or maximize the preview pane plugin:  
 <https://github.com/yazi-rs/plugins/tree/main/toggle-pane.yazi>
 
-## What does it do?
-
-This plugin previews your data files in yazi using DuckDB, with two available view modes:
-
-- Standard mode (default): Displays the file as a table.
-- Summarized mode: Uses DuckDB's summarize function, enhanced with custom formatting for readability.
-
-Supported file types:
-
-- .csv  
-- .json  
-- .parquet  
-- .tsv  
-
-## New Features
-
-- Default preview mode is now "standard."
-- Preview mode can be toggled within yazi:
-  - Press "K" at the top of the file to toggle between "standard" and "summarized."
-- Preview mode is remembered per file, even after switching files or restarting yazi.
-- Performance improvements through caching:
-  - "Standard" and "summarized" views are cached upon first load, improving scrolling performance.
-
 ## Setup and usage changes
 
 Previously, preview mode was selected by setting an environment variable (`DUCKDB_PREVIEW_MODE`).
 
 The new version no longer uses environment variables. Toggle preview modes directly within yazi using the keybinding described above.
+The default preview mode value can be set by creating an init.lua file in your config/yazi directory (the one where the plugins folder and yazi.toml file are) and adding this to it:
 
-Scrolling within both views (standard and summarized) is handled by pressing J (down) and K (up). Performance is significantly better due to caching.
+    -- duckdb plugin
+    require("duckdb"):setup({ mode = "standard" })
+
+Scrolling rows within both views (standard and summarized) is handled by pressing J (down) and K (up). Pressing K at the top of a file will change the preview mode.
 
 ## Preview
 
-<img width="1710" alt="Screenshot 2025-03-22 at 17 59 21" src="https://github.com/user-attachments/assets/ac006667-4281-4e0a-87a4-bfaeefc6f20b" />
+<img width="1710" alt="Screenshot 2025-03-22 at 18 00 06" src="https://github.com/user-attachments/assets/db09fff9-2db1-4273-9ddf-34d0bf087967" />

--- a/README.md
+++ b/README.md
@@ -2,48 +2,111 @@
 
 **Uses  [duckdb](https://github.com/duckdb/duckdb) to quickly preview and summarize data files in [yazi](https://github.com/sxyazi/yazi)!**
 
-<https://github.com/user-attachments/assets/d4a4e944-4119-4197-8e10-195520f364be>
+<br>
+
+<https://github.com/user-attachments/assets/ff2b11fb-d6fa-4b6a-b1a9-8aceed520189>
+
+<br><br>
 
 ## What does it do?
 
 This plugin previews your data files in yazi using DuckDB, with two available view modes:
 
-- Standard mode (default): Displays the file as a table
-- Summarized mode: Uses DuckDB's summarize function, enhanced with custom formatting for readability
+- Preview csv, tsv, json, or parquet files in the following modes
+    - Standard mode (default): Displays the file as a table
+    - Summarized mode: Uses DuckDB's summarize function, enhanced with custom formatting for readability
+- Preview duckdb databases
+    - See the tables and the number of rows, columns, indexes in each. Plus a list of column names in index order.
 - Scroll rows using J and K
 - Change modes by pressing K when at the top of a file
+
 
 Supported file types:
 
 - .csv  
 - .json  
 - .parquet  
-- .tsv  
+- .tsv
+- .duckdb
+- .db - if file is a duckdb database
 
-## New Features
+<br><br>
 
-### Default preview mode is now "summarized". But can be changed by creating an init.lua file in your config/yazi directory. Details below
+## New Features!
 
-- #### Preview mode can be toggled within yazi
+### Output Syntax Highlighting
+- Passes through the colors from the duckdb output as you would see if using directly in the terminal.
+- These colors can be configured in your `~/.duckdbrc` file, see the Configuration section for details.
+- Feature is only on MacOS at the moment.
+    - Planned for linux and Windows but need testers.
+    - Please support my [feature request](https://github.com/duckdb/duckdb/discussions/16885) with duckdb which will prevent the need for os specific versions and make implementation easier and more reliable.
 
-- #### Press "K" at the top of the file to toggle between "standard" and "summarized."
+**Syntax highlighting with duckdb's default color scheme.**
+<img width="700" alt="Screenshot 2025-04-02 at 14 53 38" src="https://github.com/user-attachments/assets/d2267298-b91b-496c-ae74-1d432b826f6f" />
 
-- #### Preview mode is remembered on a per session basis, rather than per file. So if you toggle to standard, it will stay as standard in that session until toggled again
+**Syntax highlighting with customized color scheme.**
+<img width="700" alt="Screenshot 2025-04-02 at 14 44 08" src="https://github.com/user-attachments/assets/965a0a4e-e4ed-4d88-ab95-84cd543f2a58" />
+
+
+### Preview DuckDC Databases
+- If you open a `.db` or `.duckdb` file directly, the plugin lists all tables in the database.
+- Each entry includes:
+  - Table name
+  - Rows Count
+  - Column count
+  - Primary key presence
+  - Index count
+  - All column names (aggregated and in index order)
+- Tables are **alphabetically ordered** and paginated for smooth scrolling.
+- Reads directly from the db in read only mode for file safety.
+  
+<img width="700" alt="Screenshot 2025-04-02 at 14 46 19" src="https://github.com/user-attachments/assets/c640d6f3-d9f6-4d98-acd8-9e4c87c6e728" />
+
+### More customisation options - row_id (row number) and width of the min/max columns
+- Row id - in standard view to help keep track when scrolling, Default is off, but can be turned on in `init.lua` options.
+- Width of min and max columns. Default is now 21 twice as wide as previously. Is now customisable in the `init.lua`, the unit is the number of characters shown.
+
+<img width="700" alt="Screenshot 2025-04-02 at 14 49 26" src="https://github.com/user-attachments/assets/6c8fb1ae-3de8-41ce-9c90-0279dc3b5e61" />
+
+<br><br>
+
+## Aditions in Previous Update
+
+### Default preview mode is now toggleable
+
+- Preview mode can be toggled within yazi
+- Press "K" at the top of the file to toggle between "standard" and "summarized."
+- Preview mode is remembered on a per session basis, rather than per file.
+- Is customisable in the `init.lua` see Configuration section.
 
 ### Performance improvements through caching
 
-- #### "Standard" and "summarized" views are cached upon first load, improving scrolling performance
+- "Standard" and "summarized" views are cached upon first load, improving scrolling performance
 
-- #### Note that on entering a directory you haven't entered before (or one containing files that have been changed) cacheing is triggered. Until cache's are generated, summarized mode may take a longer to show as it will be run on the original file, and scrolling other files during this time (especially large ones) can slow things even further as new queries on the file will be competing with cache queries. Instead it is worth waiting until the caches load (displayed in bottom right corner) or switching to standard view during these first few seconds. This will be most apparent on large, non-parquet files
+- Note that on entering a directory you haven't entered before (or one containing files that have been changed) cacheing is triggered. Until cache's are generated, summarized mode may take a longer to show as it will be run on the original file, and scrolling other files during this time (especially large ones) can slow things even further as new queries on the file will be competing with cache queries. Instead it is worth waiting until the caches load (displayed in bottom right corner) or switching to standard view during these first few seconds. This will be most apparent on large, non-parquet files
+
+<br><br>
 
 ## Installation
 
-To install, use the command:
+First you will need Yazi and DuckDB installed.
 
+- [Yazi Installation instructions](https://yazi-rs.github.io/docs/installation)
+
+- [DuckDB Installation instructions](https://duckdb.org/docs/installation/?version=stable&environment=cli&platform=macos&download_method=direct)
+
+Once these are installed you can use the yazi plugin manager to install the plugin.
+
+Use the command:
+```
 ya pack -a wylie102/duckdb
+```
+in your terminal
 
-and add to your yazi.toml:
+Then navigate to your [yazi.toml](https://yazi-rs.github.io/docs/configuration/yazi#manager.ratio) file this should be the `yazi` folder in your `config` directory
 
+and add:
+```toml
     [plugin]  
     prepend_previewers = [  
       { name = "*.csv", run = "duckdb" },  
@@ -56,39 +119,86 @@ and add to your yazi.toml:
       { name = "*.csv", run = "duckdb", multi = false },  
       { name = "*.tsv", run = "duckdb", multi = false },  
       { name = "*.json", run = "duckdb", multi = false },  
-      { name = "*.parquet", run = "duckdb", multi = false },  
+      { name = "*.parquet", run = "duckdb", multi = false },
+      { name = "*.db", run = "duckdb" },
+      { name = "*.duckdb", run = "duckdb" },
     ]
+```
+### Aditional setup and recommended plugins for more preview space
 
-If you want to change the default view then create an init.lua file in your yazi folder (where your plugin folder and yazi.toml file live. Add the following:
+Use with a larger preview window - add to your `yazi.toml`
 
-    -- duckdb plugin
-    require("duckdb"):setup({ mode = "standard" })
+```toml
+[manager]
+ratio = [1, 2, 5]
+```
+For reference the default ratio is 1, 4, 3
 
-### Yazi
+Use: 
 
-[Installation installations](https://yazi-rs.github.io/docs/installation)
+[maximize the preview pane plugin](https://github.com/yazi-rs/plugins/tree/main/toggle-pane.yazi)
 
-### duckdb
+<br><br>
 
-[Installation instructions](https://duckdb.org/docs/installation/?version=stable&environment=cli&platform=macos&download_method=direct)
+## Configuration/Customisation
 
-## Recommended plugins
+Configuration of yazi.duckdb is done via the `init.lua` file in `config/yazi` (where your plugin folder and yazi.toml file live).
+If you don't have one you can just create one. 
+Add the following:
 
-Use with a larger preview window or maximize the preview pane plugin:  
-<https://github.com/yazi-rs/plugins/tree/main/toggle-pane.yazi>
+```lua
+    -- DuckDB plugin configuration
+require("duckdb"):setup({
+  mode = "standard",            -- Default: "summarized"
+  row_id = true,                -- Default: false
+  minmax_column_width = 30      -- Default: 21
+})
+```
 
-## Setup and usage changes
+Configuration of DuckDB can be done in the `~/.duckdbrc` file.
+This should be placed in your home directory ([duckdb docs](https://duckdb.org/docs/stable/operations_manual/footprint_of_duckdb/files_created_by_duckdb)).
+
+You can customise the colors of the preview using the following options
+
+```
+.highlight_colors layout gray 
+.highlight_colors column_name magenta bold
+.highlight_colors column_type gray
+.highlight_colors string_value cyan
+.highlight_colors numeric_value green
+.highlight_colors temporal_value blue
+.highlight_colors footer gray
+```
+The above configuration is what is used in the video at the top of the readme and in the screenshots of the color highlithing section.
+Although the actual colours will depend on your terminal/yazi color scheme.
+These should be placed in your `~./duckdbrc` file as is.
+No header is needed, they are simply commands run on the startup of any duckdb instance (when using the CLI).
+These will change the color of the output in both duckdb.yazi and when using it in the CLI.
+
+Color options are:
+red|green|yellow|blue|magenta|cyan|white
+
+You can also specify bold, underline or bold_underline after the colors
+e.g. `.highlight_colors column_type red bold_underline`
+
+If the file is empty or doesn't exist then the default duckdb color scheme will be used
+This uses gray for borders and NULLs and looks like this
+
+<img width="700" alt="Screenshot 2025-04-02 at 14 53 38" src="https://github.com/user-attachments/assets/d2267298-b91b-496c-ae74-1d432b826f6f" />
+
+You can also turn the highlighting off by adding `.highlight_results off`
+In which case it will look like below. (Note this is also how it will look on non mac os systems currently).
+
+<img width="700" alt="Screenshot 2025-03-22 at 18 00 06" src="https://github.com/user-attachments/assets/db09fff9-2db1-4273-9ddf-34d0bf087967" />
+
+More information [here](https://duckdb.org/docs/stable/clients/cli/dot_commands#configuring-the-result-syntax-highlighter)
+
+<br><br>
+
+## Setup and usage changes from previous versions
 
 Previously, preview mode was selected by setting an environment variable (`DUCKDB_PREVIEW_MODE`).
 
-The new version no longer uses environment variables. Toggle preview modes directly within yazi using the keybinding described above.
-The default preview mode value can be set by creating an init.lua file in your config/yazi directory (the one where the plugins folder and yazi.toml file are) and adding this to it:
+The new version no longer uses environment variables. Toggle preview modes directly within yazi using the keybinding described in the New Features section.
+The default preview mode value can be set by creating an init.lua file in your config/yazi directory. See configuration above.
 
-    -- duckdb plugin
-    require("duckdb"):setup({ mode = "standard" })
-
-Scrolling rows within both views (standard and summarized) is handled by pressing J (down) and K (up). Pressing K at the top of a file will change the preview mode.
-
-## Preview
-
-<img width="1710" alt="Screenshot 2025-03-22 at 18 00 06" src="https://github.com/user-attachments/assets/db09fff9-2db1-4273-9ddf-34d0bf087967" />

--- a/README.md
+++ b/README.md
@@ -1,36 +1,31 @@
-
 # duckdb.yazi
 
 [duckdb](https://github.com/duckdb/duckdb) now in [yazi](https://github.com/sxyazi/yazi).
 
-<img width="1710" alt="Screenshot 2025-03-22 at 17 59 21" src="https://github.com/user-attachments/assets/ac006667-4281-4e0a-87a4-bfaeefc6f20b" />
+<img width="1710" alt="Screenshot 2025-03-22 at 18 00 06" src="https://github.com/user-attachments/assets/db09fff9-2db1-4273-9ddf-34d0bf087967" />
 
 ## Installation
 
-To install, use the command
+To install, use the command:
 
-    ya pack -a wylie102/duckdb
+ya pack -a wylie102/duckdb
 
-and add to your `yazi.toml`:
+and add to your yazi.toml:
 
-```toml
-[plugin]
-prepend_previewers = [
-  { mime = "text/csv", run = "duckdb" },
-{ name = "*.tsv", run = "duckdb" },
-  { name = "*.json", run = "duckdb" },
-  { name = "*.parquet", run = "duckdb" },
+[plugin]  
+prepend_previewers = [  
+  { mime = "text/csv", run = "duckdb" },  
+  { name = "*.tsv", run = "duckdb" },  
+  { name = "*.json", run = "duckdb" },  
+  { name = "*.parquet", run = "duckdb" },  
 ]
 
-prepend_preloaders = [
-  { mime = "text/csv", run = "duckdb", multi = false },
-  { name = "*.tsv", run = "duckdb", multi = false },
-  { name = "*.json", run = "duckdb", multi = false },
-{ name = "*.parquet", run = "duckdb", multi = false },
+prepend_preloaders = [  
+  { mime = "text/csv", run = "duckdb", multi = false },  
+  { name = "*.tsv", run = "duckdb", multi = false },  
+  { name = "*.json", run = "duckdb", multi = false },  
+  { name = "*.parquet", run = "duckdb", multi = false },  
 ]
-```
-
-## Dependencies
 
 ### Yazi
 
@@ -42,40 +37,40 @@ prepend_preloaders = [
 
 ## Recommended plugins
 
-I recommend using this with a larger size for your preview window or using the maximise preview pane plugin:
-
+Use with a larger preview window or maximize the preview pane plugin:  
 <https://github.com/yazi-rs/plugins/tree/main/toggle-pane.yazi>
 
 ## What does it do?
 
-Calls duckdb's summarize function to preview your data files.
-(Note that the display is not exactly like summarize as I added in some SQL CASE statements to make it more human readable and truncated some column outputs, the goal being to fit more in the preview window.)
+This plugin previews your data files in yazi using DuckDB, with two available view modes:
 
-Can be used on:
+- Standard mode (default): Displays the file as a table.
+- Summarized mode: Uses DuckDB's summarize function, enhanced with custom formatting for readability.
 
-- .csv
-- .json
-- .parquet
-- .tsv
+Supported file types:
 
-Can also be used to preview files in standard format, rather than summarized.
+- .csv  
+- .json  
+- .parquet  
+- .tsv  
 
-To change the mode, from the command line run:
+## New Features
 
-Summarized will display the default output summarizing each column as a row.
+- Default preview mode is now "standard."
+- Preview mode can be toggled within yazi:
+  - Press "K" at the top of the file to toggle between "standard" and "summarized."
+- Preview mode is remembered per file, even after switching files or restarting yazi.
+- Performance improvements through caching:
+  - "Standard" and "summarized" views are cached upon first load, improving scrolling performance.
 
-    export DUCKDB_PREVIEW_MODE=summarized
+## Setup and usage changes
 
-Standard returns a standard view of your file as if it were a table.
+Previously, preview mode was selected by setting an environment variable (`DUCKDB_PREVIEW_MODE`).
 
-    export DUCKDB_PREVIEW_MODE=standard
+The new version no longer uses environment variables. Toggle preview modes directly within yazi using the keybinding described above.
 
-Standard returns a standard view of your file as if it were a table.
-
-Both views are vertically scrollable with J and K.
-
-Currently scrolling in parquet in standard will perform the best, ans summarized the slowest as the query is re-run each time to move the output, but I am working on implementing caching to speed this up.
+Scrolling within both views (standard and summarized) is handled by pressing J (down) and K (up). Performance is significantly better due to caching.
 
 ## Preview
 
-<img width="1710" alt="Screenshot 2025-03-22 at 18 00 06" src="https://github.com/user-attachments/assets/db09fff9-2db1-4273-9ddf-34d0bf087967" />
+<img width="1710" alt="Screenshot 2025-03-22 at 17 59 21" src="https://github.com/user-attachments/assets/ac006667-4281-4e0a-87a4-bfaeefc6f20b" />

--- a/main.lua
+++ b/main.lua
@@ -1,96 +1,124 @@
 -- DuckDB Plugin for Yazi
 local M = {}
 
-local set_mode = ya.sync(function(state, mode)
-	state.mode = mode
+-- TODO: csv ignore errors/alternate quotes
+-- TODO: db show tables
+-- TODO: xlsx support
+-- TODO: ensure errors are transmitted in the preload function
+-- TODO: check if seek/peek still need offset
+-- TODO: turn loader bars off.
+-- TODO: row id for standard output and option to turn on or off.
+
+local set_state = ya.sync(function(state, key, value)
+	state.opts = state.opts or {}
+	state.opts[key] = value
 end)
 
-local get_mode = ya.sync(function(state)
-	return state.mode or "summarized"
+local get_state = ya.sync(function(state, key)
+	state.opts = state.opts or {}
+	return state.opts[key]
 end)
 
--- Setup from init.lua: require("duckdb"):setup({ mode = "standard" })
+-- Setup from init.lua: require("duckdb"):setup({ mode = "standard"/"summarized" })
 function M:setup(opts)
-	local default_mode = opts and opts.mode or "summarized"
-	set_mode(default_mode)
-	ya.dbg("Setup - Preview mode initialized to: " .. default_mode)
+	opts = opts or {}
+
+	local mode = opts.mode or "summarized"
+	local os = ya.target_os()
+	local column_width = opts.minmax_column_width or 21
+
+	set_state("mode", mode)
+	set_state("os", os)
+	set_state("column_width", column_width)
+
+	ya.dbg("Setup - Preview mode initialized to: " .. mode)
+	ya.dbg("Setup - OS detected as: " .. os)
+	ya.dbg("Setup - Column width set to: " .. column_width)
 end
 
--- Full summarized SQL
-local function generate_sql(job, mode)
+local function generate_preload_query(job, mode)
 	if mode == "standard" then
-		return string.format("SELECT * FROM '%s' LIMIT 500", tostring(job.file.url))
+		return string.format("FROM '%s' LIMIT 500", tostring(job.file.url))
 	else
-		return string.format(
-			[[
-			SELECT
-				column_name AS column,
-				column_type AS type,
-				count,
-				approx_unique AS unique,
-				null_percentage AS null,
-				LEFT(min, 10) AS min,
-				LEFT(max, 10) AS max,
-				CASE
-					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-					WHEN avg IS NULL THEN 'NULL'
-					WHEN TRY_CAST(avg AS DOUBLE) IS NULL THEN avg
-					WHEN CAST(avg AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(avg AS DOUBLE), 2) AS VARCHAR)
-					WHEN CAST(avg AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-					WHEN CAST(avg AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-					WHEN CAST(avg AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-					ELSE '∞'
-				END AS avg,
-				CASE
-					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-					WHEN std IS NULL THEN 'NULL'
-					WHEN TRY_CAST(std AS DOUBLE) IS NULL THEN std
-					WHEN CAST(std AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(std AS DOUBLE), 2) AS VARCHAR)
-					WHEN CAST(std AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-					WHEN CAST(std AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-					WHEN CAST(std AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-					ELSE '∞'
-				END AS std,
-				CASE
-					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-					WHEN q25 IS NULL THEN 'NULL'
-					WHEN TRY_CAST(q25 AS DOUBLE) IS NULL THEN q25
-					WHEN CAST(q25 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q25 AS DOUBLE), 2) AS VARCHAR)
-					WHEN CAST(q25 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-					WHEN CAST(q25 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-					WHEN CAST(q25 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-					ELSE '∞'
-				END AS q25,
-				CASE
-					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-					WHEN q50 IS NULL THEN 'NULL'
-					WHEN TRY_CAST(q50 AS DOUBLE) IS NULL THEN q50
-					WHEN CAST(q50 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q50 AS DOUBLE), 2) AS VARCHAR)
-					WHEN CAST(q50 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-					WHEN CAST(q50 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-					WHEN CAST(q50 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-					ELSE '∞'
-				END AS q50,
-				CASE
-					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-					WHEN q75 IS NULL THEN 'NULL'
-					WHEN TRY_CAST(q75 AS DOUBLE) IS NULL THEN q75
-					WHEN CAST(q75 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q75 AS DOUBLE), 2) AS VARCHAR)
-					WHEN CAST(q75 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-					WHEN CAST(q75 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-					WHEN CAST(q75 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-					ELSE '∞'
-				END AS q75
-			FROM (summarize FROM '%s')]],
-			tostring(job.file.url)
-		)
+		return string.format("SELECT * FROM (SUMMARIZE FROM '%s')", tostring(job.file.url))
 	end
+end
+
+local function generate_summary_cte(target)
+	column_width = get_state("column_width")
+	return string.format(
+		[[
+SELECT
+	column_name AS column,
+	column_type AS type,
+	count,
+	approx_unique AS unique,
+	null_percentage AS null,
+	LEFT(min, %d) AS min,
+	LEFT(max, %d) AS max,
+	CASE
+		WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+		WHEN avg IS NULL THEN NULL
+		WHEN TRY_CAST(avg AS DOUBLE) IS NULL THEN CAST(avg AS VARCHAR)
+		WHEN CAST(avg AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(avg AS DOUBLE), 2) AS VARCHAR)
+		WHEN CAST(avg AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+		WHEN CAST(avg AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+		WHEN CAST(avg AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+		ELSE '∞'
+	END AS avg,
+	CASE
+		WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+		WHEN std IS NULL THEN NULL
+		WHEN TRY_CAST(std AS DOUBLE) IS NULL THEN CAST(std AS VARCHAR)
+		WHEN CAST(std AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(std AS DOUBLE), 2) AS VARCHAR)
+		WHEN CAST(std AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+		WHEN CAST(std AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+		WHEN CAST(std AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+		ELSE '∞'
+	END AS std,
+	CASE
+		WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+		WHEN q25 IS NULL THEN NULL
+		WHEN TRY_CAST(q25 AS DOUBLE) IS NULL THEN CAST(q25 AS VARCHAR)
+		WHEN CAST(q25 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q25 AS DOUBLE), 2) AS VARCHAR)
+		WHEN CAST(q25 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+		WHEN CAST(q25 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+		WHEN CAST(q25 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+		ELSE '∞'
+	END AS q25,
+	CASE
+		WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+		WHEN q50 IS NULL THEN NULL
+		WHEN TRY_CAST(q50 AS DOUBLE) IS NULL THEN CAST(q50 AS VARCHAR)
+		WHEN CAST(q50 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q50 AS DOUBLE), 2) AS VARCHAR)
+		WHEN CAST(q50 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+		WHEN CAST(q50 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+		WHEN CAST(q50 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+		ELSE '∞'
+	END AS q50,
+	CASE
+		WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+		WHEN q75 IS NULL THEN NULL
+		WHEN TRY_CAST(q75 AS DOUBLE) IS NULL THEN CAST(q75 AS VARCHAR)
+		WHEN CAST(q75 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q75 AS DOUBLE), 2) AS VARCHAR)
+		WHEN CAST(q75 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+		WHEN CAST(q75 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+		WHEN CAST(q75 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+		ELSE '∞'
+	END AS q75
+FROM %s
+		]],
+		column_width,
+		column_width,
+		target
+	)
 end
 
 -- Get preview cache path
 local function get_cache_path(job, mode)
+	local cache_version = 1
 	local skip = job.skip
-	job.skip = 0
+	job.skip = 1000000 + cache_version
 	local base = ya.file_cache(job)
 	job.skip = skip
 	if not base then
@@ -99,6 +127,7 @@ local function get_cache_path(job, mode)
 	return Url(tostring(base) .. "_" .. mode .. ".db")
 end
 
+-- Run queries.
 local function run_query(job, query, target)
 	local args = {}
 	if target ~= job.file.url then
@@ -106,15 +135,53 @@ local function run_query(job, query, target)
 	end
 	table.insert(args, "-c")
 	table.insert(args, query)
+	ya.dbg(query)
 	local child = Command("duckdb"):args(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()
 	if not child then
 		return nil
 	end
 	local output, err = child:wait_with_output()
 	if err or not output.status.success then
-		ya.err("DuckDB error: " .. (err or output.stderr))
+		ya.err(err)
 		return nil
 	end
+	return output
+end
+
+local function run_query_ascii_preview_mac(job, query, target)
+	local db_path = (target ~= job.file.url) and tostring(target) or ""
+
+	local width = math.max((job.area and job.area.w * 10 or 80), 80)
+	local height = math.max((job.area and job.area.h or 25), 25)
+
+	local args = { "-q", "/dev/null", "duckdb" }
+	if db_path ~= "" then
+		table.insert(args, db_path)
+	end
+
+	-- Inject duckbox config via separate -c args before the main query
+	table.insert(args, "-c")
+	table.insert(args, string.format(".maxwidth %d", width))
+	table.insert(args, "-c")
+	table.insert(args, string.format(".maxrows %d", height))
+	table.insert(args, "-c")
+	table.insert(args, query)
+
+	ya.dbg("Running script with args: " .. table.concat(args, " "))
+
+	local child = Command("script"):args(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()
+
+	if not child then
+		ya.err("Failed to spawn script")
+		return nil
+	end
+
+	local output, err = child:wait_with_output()
+	if err or not output or not output.status.success then
+		ya.err("DuckDB (via script) error: " .. (err or output.stderr or "[unknown error]"))
+		return nil
+	end
+
 	return output
 end
 
@@ -122,32 +189,76 @@ local function create_cache(job, mode, path)
 	if fs.cha(path) then
 		return true
 	end
-	local sql = generate_sql(job, mode)
-	local out = run_query(job, string.format("CREATE TABLE My_table AS (%s);", sql), path)
+	local sql = generate_preload_query(job, mode)
+	local out = run_query(job, string.format("CREATE TABLE My_table AS %s;", sql), path)
 	return out ~= nil
 end
 
-local function generate_query(target, job, limit, offset)
-	local mode = get_mode()
-	if target == job.file.url then
-		if mode == "standard" then
-			return string.format("SELECT * FROM '%s' LIMIT %d OFFSET %d;", tostring(target), limit, offset)
-		else
-			local query = generate_sql(job, mode)
-			return string.format("WITH query AS (%s) SELECT * FROM query LIMIT %d OFFSET %d;", query, limit, offset)
-		end
+local function generate_peek_query(target, job, limit, offset)
+	local mode = get_state("mode")
+	local is_file = (target == job.file.url)
+
+	if mode == "standard" then
+		return string.format(
+			"SELECT * FROM %s LIMIT %d OFFSET %d;",
+			is_file and ("'" .. target .. "'") or "My_table",
+			limit,
+			offset
+		)
 	else
-		return string.format("SELECT * FROM My_table LIMIT %d OFFSET %d;", limit, offset)
+		local summary_source = is_file and string.format("(summarize select * from '%s')", target) or "My_table"
+
+		local summary_cte = generate_summary_cte(summary_source)
+
+		return string.format(
+			[[
+WITH summary_cte AS (
+	%s
+)
+SELECT * FROM summary_cte LIMIT %d OFFSET %d;
+]],
+			summary_cte,
+			limit,
+			offset
+		)
+	end
+end
+
+local function is_duckdb_error(output)
+	if not output or not output.stdout then
+		return true
+	end
+
+	local head = output.stdout:sub(1, 256)
+
+	if head:match("\27%[1m\27%[31m[%w%s]+Error:") then
+		return true
+	end
+
+	return false
+end
+
+local function os_run_peek_query(job, target, limit, offset)
+	local operating_system = get_state("os")
+	local query = generate_peek_query(target, job, limit, offset)
+	if operating_system == "macos" then
+		return run_query_ascii_preview_mac(job, query, target)
+	else
+		return run_query(job, query, target)
 	end
 end
 
 -- Preload summarized and standard preview caches
 function M:preload(job)
+	-- brief sleep to avoid blocking peek call when entering dir for first time.
+	ya.sleep(0.1)
 	for _, mode in ipairs({ "standard", "summarized" }) do
 		local path = get_cache_path(job, mode)
 		if path and not fs.cha(path) then
-			ya.dbg("Creating cache for mode: " .. mode)
+			local filename = job.file.url:name() or "[unknown]"
+			ya.dbg(string.format("Preload - Creating cache for mode: %s, file: %s", mode, filename))
 			create_cache(job, mode, path)
+			ya.dbg(string.format("Preload - Finished cache for mode: %s, file: %s", mode, filename))
 		end
 	end
 	return true
@@ -159,9 +270,9 @@ function M:peek(job)
 	local skip = math.max(0, raw_skip - 50)
 	job.skip = skip
 
-	ya.dbg(string.format("Peek - raw_skip: %d | adjusted skip: %d", raw_skip, skip))
+	ya.dbg(string.format("Peek - raw_skip: %d, adjusted skip: %d", raw_skip, skip))
 
-	local mode = get_mode()
+	local mode = get_state("mode")
 	ya.dbg("Peek - Mode from state: " .. mode)
 
 	local cache = get_cache_path(job, mode)
@@ -170,32 +281,38 @@ function M:peek(job)
 
 	local limit = job.area.h - 7
 	local offset = skip
-	local query = generate_query(target, job, limit, offset)
 
-	local output = run_query(job, query, target)
-
-	if not output or output.stdout == "" then
-		ya.dbg("Peek - No output from cache. Trying file directly.")
+	ya.dbg(string.format("Peek - target: %s", target))
+	local output = os_run_peek_query(job, target, limit, offset)
+	if not output or is_duckdb_error(output) then
+		if output and output.stdout then
+			ya.err("DuckDB returned an error or invalid output:\n" .. output.stdout)
+		else
+			ya.dbg("Peek - No output from cache.")
+		end
 
 		if target ~= file_url then
+			ya.dbg("Peek - Retrying directly from file.")
 			target = file_url
-			query = generate_query(target, job, limit, offset)
-			output = run_query(job, query, target)
-
-			if not output or output.stdout == "" then
-				ya.dbg("Peek - Fallback to file also failed. Showing default code preview.")
+			output = os_run_peek_query(job, target, limit, offset)
+			if not output or is_duckdb_error(output) then
+				if output and output.stdout then
+					ya.err("Fallback DuckDB output:\n" .. output.stdout)
+				end
+				ya.dbg("Peek - Fallback also failed. Showing default code preview.")
 				return require("code"):peek(job)
 			end
 		else
-			ya.dbg("Peek - No output and target was already file. Showing default code preview.")
+			ya.dbg("Peek - No cache and direct file attempt failed. Showing default code preview.")
 			return require("code"):peek(job)
 		end
 	end
 
-	ya.preview_widgets(job, { ui.Text.parse(output.stdout):area(job.area) })
+	ya.dbg(string.format("Peek - result returned for: %s", file_url:name()))
+	ya.preview_widgets(job, { ui.Text.parse(output.stdout:sub(5):gsub("\r", "")):area(job.area) })
 end
 
--- Seek with debug output
+-- Seek, also triggers mode change if skip negative.
 function M:seek(job)
 	local OFFSET_BASE = 50
 	local current_skip = math.max(0, cx.active.preview.skip - OFFSET_BASE)
@@ -204,9 +321,9 @@ function M:seek(job)
 
 	if new_skip < 0 then
 		-- Toggle preview mode
-		local mode = get_mode()
+		local mode = get_state("mode")
 		local new_mode = (mode == "summarized") and "standard" or "summarized"
-		set_mode(new_mode)
+		set_state("mode", new_mode)
 		ya.dbg("Seek - Toggled mode to: " .. new_mode)
 
 		-- Trigger re-peek

--- a/main.lua
+++ b/main.lua
@@ -214,17 +214,27 @@ local function generate_peek_query(target, job, limit, offset)
 	local name = job.file.url:name() or ""
 	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
 		ya.dbg("target is a database, getting tables.")
-		return [[select
-  distinct t.table_name,
-  t.has_primary_key,
-  t.estimated_size,
-  t.column_count,
-  t.index_count,
-  string_agg(c.column_name, ', ') over (partition by t.table_name) as columns
-from duckdb_tables() t
-left join duckdb_columns() c
-  on t.table_name = c.table_name
-  order by t.table_name;]]
+		return string.format(
+			[[
+WITH table_info AS (
+  SELECT
+    DISTINCT t.table_name,
+    t.estimated_size as rows,
+    t.column_count as columns,
+    t.has_primary_key as has_pk,
+    t.index_count as indexes,
+    STRING_AGG(c.column_name, ', ' ORDER BY c.column_index) OVER (PARTITION BY t.table_name) AS column_names
+  FROM duckdb_tables() t
+  LEFT JOIN duckdb_columns() c
+    ON t.table_name = c.table_name
+  ORDER BY t.table_name
+)
+SELECT * FROM table_info
+LIMIT %d OFFSET %d;
+]],
+			limit,
+			offset
+		)
 	end
 	if mode == "standard" then
 		return string.format(

--- a/main.lua
+++ b/main.lua
@@ -147,7 +147,7 @@ end
 
 -- Get preview cache path
 local function get_cache_path(job, mode)
-	local cache_version = 1
+	local cache_version = 2
 	local skip = job.skip
 	job.skip = 1000000 + cache_version
 	local base = ya.file_cache(job)

--- a/main.lua
+++ b/main.lua
@@ -2,7 +2,6 @@
 local M = {}
 
 -- TODO: csv ignore errors/alternate quotes
--- TODO: db show tables
 -- TODO: xlsx support
 -- TODO: ensure errors are transmitted in the preload function
 -- TODO: side scrolling using SELECT * EXCEPT(2) -> EXCEPT (2,3)
@@ -134,6 +133,11 @@ local function run_query(job, query, target)
 	if target ~= job.file.url then
 		table.insert(args, tostring(target))
 	end
+	local name = job.file.url:name() or ""
+	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
+		table.insert(args, "-readonly")
+		table.insert(args, tostring(target))
+	end
 	table.insert(args, "-c")
 	table.insert(args, query)
 	ya.dbg(query)
@@ -158,6 +162,11 @@ local function run_query_ascii_preview_mac(job, query, target)
 	local args = { "-q", "/dev/null", "duckdb" }
 	if db_path ~= "" then
 		table.insert(args, db_path)
+	end
+	local name = job.file.url:name() or ""
+	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
+		table.insert(args, "-readonly")
+		table.insert(args, tostring(target))
 	end
 
 	-- Inject duckbox config via separate -c args before the main query
@@ -202,6 +211,21 @@ local function generate_peek_query(target, job, limit, offset)
 	local row_id = get_state("row_id")
 	local is_file = (target == job.file.url)
 
+	local name = job.file.url:name() or ""
+	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
+		ya.dbg("target is a database, getting tables.")
+		return [[select
+  distinct t.table_name,
+  t.has_primary_key,
+  t.estimated_size,
+  t.column_count,
+  t.index_count,
+  string_agg(c.column_name, ', ') over (partition by t.table_name) as columns
+from duckdb_tables() t
+left join duckdb_columns() c
+  on t.table_name = c.table_name
+  order by t.table_name;]]
+	end
 	if mode == "standard" then
 		return string.format(
 			"SELECT %s* FROM %s LIMIT %d OFFSET %d;",

--- a/main.lua
+++ b/main.lua
@@ -1,10 +1,29 @@
--- This function generates the SQL query based on the preview mode.
+-- DuckDB Plugin for Yazi
+local M = {}
+
+local set_mode = ya.sync(function(state, mode)
+	state.mode = mode
+end)
+
+local get_mode = ya.sync(function(state)
+	return state.mode or "summarized"
+end)
+
+-- Setup from init.lua: require("duckdb"):setup({ mode = "standard" })
+function M:setup(opts)
+	local default_mode = opts and opts.mode or "summarized"
+	set_mode(default_mode)
+	ya.dbg("Setup - Preview mode initialized to: " .. default_mode)
+end
+
+-- Full summarized SQL
 local function generate_sql(job, mode)
 	if mode == "standard" then
 		return string.format("SELECT * FROM '%s' LIMIT 500", tostring(job.file.url))
 	else
 		return string.format(
-			[[SELECT
+			[[
+			SELECT
 				column_name AS column,
 				column_type AS type,
 				count,
@@ -68,7 +87,8 @@ local function generate_sql(job, mode)
 	end
 end
 
-local function get_cache_path(job, type)
+-- Get preview cache path
+local function get_cache_path(job, mode)
 	local skip = job.skip
 	job.skip = 0
 	local base = ya.file_cache(job)
@@ -76,8 +96,7 @@ local function get_cache_path(job, type)
 	if not base then
 		return nil
 	end
-	local suffix = ({ standard = "_standard.db", summarized = "_summarized.db", mode = "_mode.db" })[type or "standard"]
-	return Url(tostring(base) .. suffix)
+	return Url(tostring(base) .. "_" .. mode .. ".db")
 end
 
 local function run_query(job, query, target)
@@ -92,52 +111,24 @@ local function run_query(job, query, target)
 		return nil
 	end
 	local output, err = child:wait_with_output()
-	if err then
-		return nil
-	end
-	if not output.status.success then
-		ya.err("DuckDB exited with error: " .. output.stderr)
+	if err or not output.status.success then
+		ya.err("DuckDB error: " .. (err or output.stderr))
 		return nil
 	end
 	return output
 end
 
 local function create_cache(job, mode, path)
-	local filename = job.file.url:name() or "unknown"
 	if fs.cha(path) then
 		return true
 	end
-	local sql = (mode == "mode") and "CREATE TABLE My_table AS SELECT 'standard' AS Preview_mode;"
-		or string.format("CREATE TABLE My_table AS (%s);", generate_sql(job, mode))
-	local out = run_query(job, sql, path, mode == "mode" and "mode" or nil)
-	if not out then
-		ya.err("Preload - Failed to generate " .. mode .. " cache for file: " .. tostring(filename) .. ".")
-		return false
-	end
-	return true
-end
-
-local function get_preview_mode(job)
-	local mode = "standard"
-	local mode_cache = get_cache_path(job, "mode")
-	if not mode_cache then
-		return mode
-	end
-	if not fs.cha(mode_cache) then
-		create_cache(job, "mode", mode_cache)
-	end
-	local result = run_query(job, "SELECT Preview_mode FROM My_table LIMIT 1;", mode_cache, "mode")
-	if result and result.stdout and result.stdout ~= "" then
-		local value = result.stdout:lower()
-		if value:match("summarized") then
-			mode = "summarized"
-		end
-	end
-	return mode
+	local sql = generate_sql(job, mode)
+	local out = run_query(job, string.format("CREATE TABLE My_table AS (%s);", sql), path)
+	return out ~= nil
 end
 
 local function generate_query(target, job, limit, offset)
-	local mode = get_preview_mode(job)
+	local mode = get_mode()
 	if target == job.file.url then
 		if mode == "standard" then
 			return string.format("SELECT * FROM '%s' LIMIT %d OFFSET %d;", tostring(target), limit, offset)
@@ -150,82 +141,79 @@ local function generate_query(target, job, limit, offset)
 	end
 end
 
-local function set_preview_mode(job, mode)
-	local mode_cache = get_cache_path(job, "mode")
-	if not mode_cache then
-		return false
-	end
-	run_query(job, "DELETE FROM My_table;", mode_cache, "mode")
-	local sql = string.format("INSERT INTO My_table VALUES ('%s');", mode)
-	local result = run_query(job, sql, mode_cache, "mode")
-	if not result then
-		ya.err("SetPreviewMode - Failed to update preview mode.")
-		return false
+-- Preload summarized and standard preview caches
+function M:preload(job)
+	for _, mode in ipairs({ "standard", "summarized" }) do
+		local path = get_cache_path(job, mode)
+		if path and not fs.cha(path) then
+			ya.dbg("Creating cache for mode: " .. mode)
+			create_cache(job, mode, path)
+		end
 	end
 	return true
 end
 
-local M = {}
-
-function M:preload(job)
-	local cache_standard = get_cache_path(job, "standard")
-	local cache_summarized = get_cache_path(job, "summarized")
-	if not cache_standard or not cache_summarized then
-		return false
-	end
-	if fs.cha(cache_standard) and fs.cha(cache_summarized) then
-		return true
-	end
-	local success = true
-	success = create_cache(job, "standard", cache_standard) and success
-	success = create_cache(job, "summarized", cache_summarized) and success
-	return success
-end
-
+-- Peek with mode toggle if scrolling at top
 function M:peek(job)
 	local raw_skip = job.skip or 0
 	local skip = math.max(0, raw_skip - 50)
-	if raw_skip > 0 and raw_skip < 50 then
-		local current_mode = get_preview_mode(job)
-		local new_mode = current_mode == "standard" and "summarized" or "standard"
-		set_preview_mode(job, new_mode)
-		skip = 0
-	end
 	job.skip = skip
-	local mode = get_preview_mode(job)
+
+	ya.dbg(string.format("Peek - raw_skip: %d | adjusted skip: %d", raw_skip, skip))
+
+	local mode = get_mode()
+	ya.dbg("Peek - Mode from state: " .. mode)
+
 	local cache = get_cache_path(job, mode)
 	local file_url = job.file.url
-	local target = cache
+	local target = (cache and fs.cha(cache)) and cache or file_url
+
 	local limit = job.area.h - 7
 	local offset = skip
-	if not cache or not fs.cha(cache) then
-		target = file_url
-	end
 	local query = generate_query(target, job, limit, offset)
+
 	local output = run_query(job, query, target)
+
 	if not output or output.stdout == "" then
+		ya.dbg("Peek - No output from cache. Trying file directly.")
+
 		if target ~= file_url then
 			target = file_url
 			query = generate_query(target, job, limit, offset)
 			output = run_query(job, query, target)
+
 			if not output or output.stdout == "" then
+				ya.dbg("Peek - Fallback to file also failed. Showing default code preview.")
 				return require("code"):peek(job)
 			end
 		else
+			ya.dbg("Peek - No output and target was already file. Showing default code preview.")
 			return require("code"):peek(job)
 		end
 	end
+
 	ya.preview_widgets(job, { ui.Text.parse(output.stdout):area(job.area) })
 end
 
+-- Seek with debug output
 function M:seek(job)
 	local OFFSET_BASE = 50
-	local encoded_current_skip = cx.active.preview.skip or 0
-	local current_skip = math.max(0, encoded_current_skip - OFFSET_BASE)
+	local current_skip = math.max(0, cx.active.preview.skip - OFFSET_BASE)
 	local units = job.units or 0
 	local new_skip = current_skip + units
-	local encoded_skip = new_skip + OFFSET_BASE
-	ya.manager_emit("peek", { encoded_skip, only_if = job.file.url })
+
+	if new_skip < 0 then
+		-- Toggle preview mode
+		local mode = get_mode()
+		local new_mode = (mode == "summarized") and "standard" or "summarized"
+		set_mode(new_mode)
+		ya.dbg("Seek - Toggled mode to: " .. new_mode)
+
+		-- Trigger re-peek
+		ya.manager_emit("peek", { OFFSET_BASE, only_if = job.file.url })
+	else
+		ya.manager_emit("peek", { new_skip + OFFSET_BASE, only_if = job.file.url })
+	end
 end
 
 return M

--- a/main.lua
+++ b/main.lua
@@ -6,7 +6,6 @@ local M = {}
 -- TODO: xlsx support
 -- TODO: ensure errors are transmitted in the preload function
 -- TODO: check if seek/peek still need offset
--- TODO: turn loader bars off.
 -- TODO: row id for standard output and option to turn on or off.
 
 local set_state = ya.sync(function(state, key, value)
@@ -160,6 +159,8 @@ local function run_query_ascii_preview_mac(job, query, target)
 	end
 
 	-- Inject duckbox config via separate -c args before the main query
+	table.insert(args, "-c")
+	table.insert(args, "SET enable_progress_bar = false;")
 	table.insert(args, "-c")
 	table.insert(args, string.format(".maxwidth %d", width))
 	table.insert(args, "-c")

--- a/main.lua
+++ b/main.lua
@@ -127,7 +127,13 @@ end
 -- Peek Function
 function M:peek(job)
 	-- store cache and mode variables.
+	ya.dbg("Peek - file:" .. tostring(job.file.url))
+	ya.dbg("Peek - mtime:" .. tostring(job.file.cha.mtime))
+	local limit = job.area.h - 7
+	local offset = job.skip or 0
+	job.skip = 0
 	local cache = ya.file_cache(job)
+	job.skip = offset
 	local mode = os.getenv("DUCKDB_PREVIEW_MODE") or "summarized"
 
 	-- if no cache url use default previewer.
@@ -149,8 +155,6 @@ function M:peek(job)
 	end
 
 	-- Store and lof limit and offset variables.
-	local limit = job.area.h - 2
-	local offset = job.skip or 0
 	ya.dbg("Peek - Limit: " .. tostring(limit) .. ", Offset: " .. tostring(offset))
 
 	-- store table name variable.
@@ -195,6 +199,8 @@ end
 
 -- Seek function.
 function M:seek(job)
+	ya.dbg("Seek - file:" .. tostring(job.file.url))
+	ya.dbg("Seek - mtime:" .. tostring(job.file.cha.mtime))
 	local h = cx.active.current.hovered
 	if not h or h.url ~= job.file.url then
 		return

--- a/main.lua
+++ b/main.lua
@@ -8,7 +8,7 @@ local M = {}
 
 local function log_timing(file, mode, label, duration)
 	local home = os.getenv("HOME") or "/tmp"
-	local log_path = "/Users/wylie/Desktop/Projects/duckdb.yazi_timings/duckdb-timings-db.csv"
+	local log_path = "/Users/wylie/Desktop/Projects/duckdb.yazi_timings/duckdb-timings-parquet.csv"
 	local exists = fs.cha(Url(log_path))
 
 	local row = string.format("%s,%s,%s,%.6f\n", file, mode, label, duration)
@@ -158,14 +158,15 @@ local function get_cache_path(job, mode)
 	return Url(tostring(base) .. "_" .. mode .. ".parquet")
 end
 
+local function is_duckdb_database(path)
+	local name = path:name() or ""
+	return name:match("%.duckdb$") or name:match("%.db$")
+end
+
 -- Run queries.
 local function run_query(job, query, target)
 	local args = {}
-	if target ~= job.file.url then
-		table.insert(args, tostring(target))
-	end
-	local name = job.file.url:name() or ""
-	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
+	if is_duckdb_database(target) then
 		table.insert(args, "-readonly")
 		table.insert(args, tostring(target))
 	end
@@ -186,17 +187,11 @@ local function run_query(job, query, target)
 end
 
 local function run_query_ascii_preview_mac(job, query, target)
-	local db_path = (target ~= job.file.url) and tostring(target) or ""
-
 	local width = math.max((job.area and job.area.w * 3 or 80), 80)
 	local height = math.max((job.area and job.area.h or 25), 25)
 
 	local args = { "-q", "/dev/null", "duckdb" }
-	if db_path ~= "" then
-		table.insert(args, db_path)
-	end
-	local name = job.file.url:name() or ""
-	if target == job.file.url and (name:match("%.db$") or name:match("%.duckdb$")) then
+	if is_duckdb_database(target) then
 		table.insert(args, "-readonly")
 		table.insert(args, tostring(target))
 	end
@@ -241,11 +236,6 @@ local function create_cache(job, mode, path)
 			run_query(job, string.format("COPY (%s) TO '%s' (FORMAT 'parquet');", sql, tostring(path)), job.file.url)
 		return out ~= nil
 	end)
-end
-
-local function is_duckdb_database(path)
-	local name = path:name() or ""
-	return name:match("%.duckdb$") or name:match("%.db$")
 end
 
 local function generate_peek_query(target, job, limit, offset)

--- a/main.lua
+++ b/main.lua
@@ -1,213 +1,231 @@
-local M = {}
-
 -- This function generates the SQL query based on the preview mode.
 local function generate_sql(job, mode)
-	local initial_query = ""
 	if mode == "standard" then
-		initial_query = string.format("SELECT * FROM '%s' LIMIT 500", tostring(job.file.url))
+		return string.format("SELECT * FROM '%s' LIMIT 500", tostring(job.file.url))
 	else
-		initial_query = string.format(
-			[[
-    SELECT
-        column_name AS column,
-        column_type AS type,
-        count,
-        approx_unique AS unique,
-        null_percentage AS null,
-        LEFT(min, 10) AS min,
-        LEFT(max, 10) AS max,
-        CASE
-            WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-            WHEN avg IS NULL THEN 'NULL'
-            WHEN TRY_CAST(avg AS DOUBLE) IS NULL THEN avg
-            WHEN CAST(avg AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(avg AS DOUBLE), 2) AS VARCHAR)
-            WHEN CAST(avg AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-            WHEN CAST(avg AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-            WHEN CAST(avg AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-            ELSE '∞'
-        END AS avg,
-        CASE
-            WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-            WHEN std IS NULL THEN 'NULL'
-            WHEN TRY_CAST(std AS DOUBLE) IS NULL THEN std
-            WHEN CAST(std AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(std AS DOUBLE), 2) AS VARCHAR)
-            WHEN CAST(std AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-            WHEN CAST(std AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-            WHEN CAST(std AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-            ELSE '∞'
-        END AS std,
-        CASE
-            WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-            WHEN q25 IS NULL THEN 'NULL'
-            WHEN TRY_CAST(q25 AS DOUBLE) IS NULL THEN q25
-            WHEN CAST(q25 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q25 AS DOUBLE), 2) AS VARCHAR)
-            WHEN CAST(q25 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-            WHEN CAST(q25 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-            WHEN CAST(q25 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-              ELSE '∞'
-        END AS q25,
-        CASE
-            WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-            WHEN q50 IS NULL THEN 'NULL'
-            WHEN TRY_CAST(q50 AS DOUBLE) IS NULL THEN q50
-            WHEN CAST(q50 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q50 AS DOUBLE), 2) AS VARCHAR)
-            WHEN CAST(q50 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-            WHEN CAST(q50 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-            WHEN CAST(q50 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-            ELSE '∞'
-        END AS q50,
-        CASE
-            WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
-            WHEN q75 IS NULL THEN 'NULL'
-            WHEN TRY_CAST(q75 AS DOUBLE) IS NULL THEN q75
-            WHEN CAST(q75 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q75 AS DOUBLE), 2) AS VARCHAR)
-            WHEN CAST(q75 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
-            WHEN CAST(q75 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
-            WHEN CAST(q75 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
-            ELSE '∞'
-        END AS q75
-    FROM (summarize FROM '%s')
-      ]],
+		return string.format(
+			[[SELECT
+				column_name AS column,
+				column_type AS type,
+				count,
+				approx_unique AS unique,
+				null_percentage AS null,
+				LEFT(min, 10) AS min,
+				LEFT(max, 10) AS max,
+				CASE
+					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+					WHEN avg IS NULL THEN 'NULL'
+					WHEN TRY_CAST(avg AS DOUBLE) IS NULL THEN avg
+					WHEN CAST(avg AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(avg AS DOUBLE), 2) AS VARCHAR)
+					WHEN CAST(avg AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+					WHEN CAST(avg AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+					WHEN CAST(avg AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(avg AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+					ELSE '∞'
+				END AS avg,
+				CASE
+					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+					WHEN std IS NULL THEN 'NULL'
+					WHEN TRY_CAST(std AS DOUBLE) IS NULL THEN std
+					WHEN CAST(std AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(std AS DOUBLE), 2) AS VARCHAR)
+					WHEN CAST(std AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+					WHEN CAST(std AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+					WHEN CAST(std AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(std AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+					ELSE '∞'
+				END AS std,
+				CASE
+					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+					WHEN q25 IS NULL THEN 'NULL'
+					WHEN TRY_CAST(q25 AS DOUBLE) IS NULL THEN q25
+					WHEN CAST(q25 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q25 AS DOUBLE), 2) AS VARCHAR)
+					WHEN CAST(q25 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+					WHEN CAST(q25 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+					WHEN CAST(q25 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q25 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+					ELSE '∞'
+				END AS q25,
+				CASE
+					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+					WHEN q50 IS NULL THEN 'NULL'
+					WHEN TRY_CAST(q50 AS DOUBLE) IS NULL THEN q50
+					WHEN CAST(q50 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q50 AS DOUBLE), 2) AS VARCHAR)
+					WHEN CAST(q50 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+					WHEN CAST(q50 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+					WHEN CAST(q50 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q50 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+					ELSE '∞'
+				END AS q50,
+				CASE
+					WHEN column_type IN ('TIMESTAMP', 'DATE') THEN '-'
+					WHEN q75 IS NULL THEN 'NULL'
+					WHEN TRY_CAST(q75 AS DOUBLE) IS NULL THEN q75
+					WHEN CAST(q75 AS DOUBLE) < 100000 THEN CAST(ROUND(CAST(q75 AS DOUBLE), 2) AS VARCHAR)
+					WHEN CAST(q75 AS DOUBLE) < 1000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000, 1) AS VARCHAR) || 'k'
+					WHEN CAST(q75 AS DOUBLE) < 1000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000, 2) AS VARCHAR) || 'm'
+					WHEN CAST(q75 AS DOUBLE) < 1000000000000 THEN CAST(ROUND(CAST(q75 AS DOUBLE) / 1000000000, 2) AS VARCHAR) || 'b'
+					ELSE '∞'
+				END AS q75
+			FROM (summarize FROM '%s')]],
 			tostring(job.file.url)
 		)
 	end
-	return initial_query
 end
 
--- Preload function: outputs the query result to a parquet file (cache) using DuckDB's COPY.
-function M:preload(job)
-	local cache = ya.file_cache(job)
-	if not cache then
-		ya.dbg("Preload - No cache url found.")
-		return false
+local function get_cache_path(job, type)
+	local skip = job.skip
+	job.skip = 0
+	local base = ya.file_cache(job)
+	job.skip = skip
+	if not base then
+		return nil
 	end
+	local suffix = ({ standard = "_standard.db", summarized = "_summarized.db", mode = "_mode.db" })[type or "standard"]
+	return Url(tostring(base) .. suffix)
+end
 
-	-- If the cache file already exists, no need to preload.
-	if fs.cha(cache) then
-		ya.dbg("Preload - Cache already exists (fs.cha returned true)")
+local function run_query(job, query, target)
+	local args = {}
+	if target ~= job.file.url then
+		table.insert(args, tostring(target))
+	end
+	table.insert(args, "-c")
+	table.insert(args, query)
+	local child = Command("duckdb"):args(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()
+	if not child then
+		return nil
+	end
+	local output, err = child:wait_with_output()
+	if err then
+		return nil
+	end
+	if not output.status.success then
+		ya.err("DuckDB exited with error: " .. output.stderr)
+		return nil
+	end
+	return output
+end
+
+local function create_cache(job, mode, path)
+	local filename = job.file.url:name() or "unknown"
+	if fs.cha(path) then
 		return true
 	end
-
-	-- Generate basic sql statements.
-	local standard_sql = generate_sql(job, "standard")
-	local summarized_sql = generate_sql(job, "summarized")
-	ya.dbg("Preload -  basic query statements returned.")
-
-	-- Generate create table statements.
-	local create_table_standard = string.format("CREATE TABLE Standard AS (%s);", standard_sql)
-	local create_table_summarized = string.format("CREATE TABLE Summarized AS (%s);", summarized_sql)
-	ya.dbg("Preload - create table statements returned.")
-
-	-- Sleep for 0.01s to avoid blocking peek process on first file highlighted.
-	ya.sleep(0.01)
-
-	-- Create database and run queries to create tables.
-	local child = Command("duckdb")
-		:args({ tostring(cache), "-c", create_table_summarized, "-c", create_table_standard })
-		:stdout(Command.PIPED)
-		:stderr(Command.PIPED)
-		:spawn()
-	if not child then
-		ya.dbg("Preload - Failed to initialise db and store created tables.")
+	local sql = (mode == "mode") and "CREATE TABLE My_table AS SELECT 'standard' AS Preview_mode;"
+		or string.format("CREATE TABLE My_table AS (%s);", generate_sql(job, mode))
+	local out = run_query(job, sql, path, mode == "mode" and "mode" or nil)
+	if not out then
+		ya.err("Preload - Failed to generate " .. mode .. " cache for file: " .. tostring(filename) .. ".")
 		return false
 	end
-
-	-- Wait for completion and return any errors.
-	local output, err = child:wait_with_output()
-	if err or not output or (output.stderr and output.stderr ~= "") then
-		ya.err("DuckDB preloader error: " .. (err or output.stderr))
-		return false
-	end
-
-	-- tables created.
-	ya.dbg("Preload - Db and tables created.")
 	return true
 end
 
--- Peek Function
-function M:peek(job)
-	-- store cache and mode variables.
-	ya.dbg("Peek - file:" .. tostring(job.file.url))
-	ya.dbg("Peek - mtime:" .. tostring(job.file.cha.mtime))
-	local limit = job.area.h - 7
-	local offset = job.skip or 0
-	job.skip = 0
-	local cache = ya.file_cache(job)
-	job.skip = offset
-	local mode = os.getenv("DUCKDB_PREVIEW_MODE") or "summarized"
-
-	-- if no cache url use default previewer.
-	if not cache then
-		ya.dbg("Peek - No cache url found. Using default preview.")
-		return require("code"):peek(job)
+local function get_preview_mode(job)
+	local mode = "standard"
+	local mode_cache = get_cache_path(job, "mode")
+	if not mode_cache then
+		return mode
 	end
+	if not fs.cha(mode_cache) then
+		create_cache(job, "mode", mode_cache)
+	end
+	local result = run_query(job, "SELECT Preview_mode FROM My_table LIMIT 1;", mode_cache, "mode")
+	if result and result.stdout and result.stdout ~= "" then
+		local value = result.stdout:lower()
+		if value:match("summarized") then
+			mode = "summarized"
+		end
+	end
+	return mode
+end
 
-	-- echo cache path to log.
-	ya.dbg("Peek - Cache path: " .. tostring(cache))
+local function generate_query(target, job, limit, offset)
+	local mode = get_preview_mode(job)
+	if target == job.file.url then
+		if mode == "standard" then
+			return string.format("SELECT * FROM '%s' LIMIT %d OFFSET %d;", tostring(target), limit, offset)
+		else
+			local query = generate_sql(job, mode)
+			return string.format("WITH query AS (%s) SELECT * FROM query LIMIT %d OFFSET %d;", query, limit, offset)
+		end
+	else
+		return string.format("SELECT * FROM My_table LIMIT %d OFFSET %d;", limit, offset)
+	end
+end
 
-	-- If the cache does not exist yet, try preloading.
-	if not fs.cha(cache) then
-		ya.dbg("Peek - Cache not found on disk, attempting to preload")
-		if not self:preload(job) then
-			ya.dbg("Peek - Preload failed. Using default preview")
+local function set_preview_mode(job, mode)
+	local mode_cache = get_cache_path(job, "mode")
+	if not mode_cache then
+		return false
+	end
+	run_query(job, "DELETE FROM My_table;", mode_cache, "mode")
+	local sql = string.format("INSERT INTO My_table VALUES ('%s');", mode)
+	local result = run_query(job, sql, mode_cache, "mode")
+	if not result then
+		ya.err("SetPreviewMode - Failed to update preview mode.")
+		return false
+	end
+	return true
+end
+
+local M = {}
+
+function M:preload(job)
+	local cache_standard = get_cache_path(job, "standard")
+	local cache_summarized = get_cache_path(job, "summarized")
+	if not cache_standard or not cache_summarized then
+		return false
+	end
+	if fs.cha(cache_standard) and fs.cha(cache_summarized) then
+		return true
+	end
+	local success = true
+	success = create_cache(job, "standard", cache_standard) and success
+	success = create_cache(job, "summarized", cache_summarized) and success
+	return success
+end
+
+function M:peek(job)
+	local raw_skip = job.skip or 0
+	local skip = math.max(0, raw_skip - 50)
+	if raw_skip > 0 and raw_skip < 50 then
+		local current_mode = get_preview_mode(job)
+		local new_mode = current_mode == "standard" and "summarized" or "standard"
+		set_preview_mode(job, new_mode)
+		skip = 0
+	end
+	job.skip = skip
+	local mode = get_preview_mode(job)
+	local cache = get_cache_path(job, mode)
+	local file_url = job.file.url
+	local target = cache
+	local limit = job.area.h - 7
+	local offset = skip
+	if not cache or not fs.cha(cache) then
+		target = file_url
+	end
+	local query = generate_query(target, job, limit, offset)
+	local output = run_query(job, query, target)
+	if not output or output.stdout == "" then
+		if target ~= file_url then
+			target = file_url
+			query = generate_query(target, job, limit, offset)
+			output = run_query(job, query, target)
+			if not output or output.stdout == "" then
+				return require("code"):peek(job)
+			end
+		else
 			return require("code"):peek(job)
 		end
 	end
-
-	-- Store and lof limit and offset variables.
-	ya.dbg("Peek - Limit: " .. tostring(limit) .. ", Offset: " .. tostring(offset))
-
-	-- store table name variable.
-	local queried_table = ""
-	if mode == "standard" then
-		queried_table = "Standard"
-	else
-		queried_table = "Summarized"
-	end
-
-	-- Generate query.
-	local query = string.format("SELECT * FROM %s LIMIT %d OFFSET %d;", queried_table, limit, offset)
-	ya.dbg("Peek - SQL Query: " .. query)
-
-	-- Run query.
-	local child =
-		Command("duckdb"):args({ tostring(cache), "-c", query }):stdout(Command.PIPED):stderr(Command.PIPED):spawn()
-
-	-- If query fails use standerd preview.
-	if not child then
-		ya.dbg("Peek - Failed to spawn DuckDB command, falling back")
-		return require("code"):peek(job)
-	end
-
-	-- Wait on result, if error use standard previewer.
-	local output, err = child:wait_with_output()
-	if err then
-		ya.dbg("DuckDB command error: " .. tostring(err))
-		return require("code"):peek(job)
-	end
-
-	-- If query returns no output then use standard previewer.
-	if output.stdout == "" then
-		ya.dbg("DuckDB returned no output.")
-		return require("code"):peek(job)
-	end
-
-	-- If query returns data, log success and preview.
-	ya.dbg("Peek - Query succesfully returned data.")
 	ya.preview_widgets(job, { ui.Text.parse(output.stdout):area(job.area) })
 end
 
--- Seek function.
 function M:seek(job)
-	ya.dbg("Seek - file:" .. tostring(job.file.url))
-	ya.dbg("Seek - mtime:" .. tostring(job.file.cha.mtime))
-	local h = cx.active.current.hovered
-	if not h or h.url ~= job.file.url then
-		return
-	end
-	local current_skip = cx.active.preview.skip or 0
-	local new_skip = math.max(0, current_skip + job.units)
-	ya.manager_emit("peek", { new_skip, only_if = job.file.url })
+	local OFFSET_BASE = 50
+	local encoded_current_skip = cx.active.preview.skip or 0
+	local current_skip = math.max(0, encoded_current_skip - OFFSET_BASE)
+	local units = job.units or 0
+	local new_skip = current_skip + units
+	local encoded_skip = new_skip + OFFSET_BASE
+	ya.manager_emit("peek", { encoded_skip, only_if = job.file.url })
 end
 
 return M


### PR DESCRIPTION
Changes the cache system to use parquet files instead of duckdb files.
- Much reduced storage size 1/10th size on average.
- Similar or slightly improved performance both on cache generation and on preview, (which was surprising).

Updated file identification logic and SQL queries to reflect this.