### PR TITLE
Changes cache system to use parquet files instead of duckdb files.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -106,7 +106,7 @@ end
 
 -- Get preview cache path
 local function get_cache_path(job, mode)
-	local cache_version = 1
+	local cache_version = 2
 	local skip = job.skip
 	job.skip = 1000000 + cache_version
 	local base = ya.file_cache(job)


### PR DESCRIPTION
Changes the cache system to use parquet files instead of duckdb files.
- Much reduced storage size 1/10th size on average.
- Similar or slightly improved performance both on cache generation and on preview, (which was surprising).


Updated file identification logic and SQL queries to reflect this.