### PR TITLE
Remove extra spaces in #yazitoml codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,24 +148,24 @@ Then navigate to your [yazi.toml](https://yazi-rs.github.io/docs/configuration/y
 and add:
 
 ```toml
-[plugin]  
-prepend_previewers = [  
-  { name = "*.csv", run = "duckdb" },  
-  { name = "*.tsv", run = "duckdb" },  
-  { name = "*.json", run = "duckdb" },  
-  { name = "*.parquet", run = "duckdb" },  
-  { name = "*.txt", run = "duckdb" },  
-  { name = "*.xlsx", run = "duckdb" },  
+[plugin]
+prepend_previewers = [
+  { name = "*.csv", run = "duckdb" },
+  { name = "*.tsv", run = "duckdb" },
+  { name = "*.json", run = "duckdb" },
+  { name = "*.parquet", run = "duckdb" },
+  { name = "*.txt", run = "duckdb" },
+  { name = "*.xlsx", run = "duckdb" },
   { name = "*.db", run = "duckdb" },
   { name = "*.duckdb", run = "duckdb" }
 ]
 
-prepend_preloaders = [  
-  { name = "*.csv", run = "duckdb", multi = false },  
-  { name = "*.tsv", run = "duckdb", multi = false },  
-  { name = "*.json", run = "duckdb", multi = false },  
+prepend_preloaders = [
+  { name = "*.csv", run = "duckdb", multi = false },
+  { name = "*.tsv", run = "duckdb", multi = false },
+  { name = "*.json", run = "duckdb", multi = false },
   { name = "*.parquet", run = "duckdb", multi = false },
-  { name = "*.txt", run = "duckdb", multi = false },  
+  { name = "*.txt", run = "duckdb", multi = false },
   { name = "*.xlsx", run = "duckdb", multi = false }
 ]
 ```


### PR DESCRIPTION
I feel silly even making this pull request because nobody will even notice this change. The only reason I did is because I copied the configuration code into a NixOS file and was trying to use Helix to change the TOML to valid Nix.