### PR TITLE
Fix command and update DuckDB plugin settings in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,22 +197,22 @@ This is where the configuration/settings can go ([see below](https://github.com/
 Then in your [keymap.toml](https://yazi-rs.github.io/docs/configuration/keymap) file add:
 
 ```toml
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on = "H"
 run = "plugin duckdb -1"
 desc = "Scroll one column to the left"
 
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on = "L"
 run = "plugin duckdb +1"
 desc = "Scroll one column to the right"
 
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on = ["g", "o"]
 run = "plugin duckdb -open"
 desc = "open with duckdb"
 
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on = ["g", "u"]
 run = "plugin duckdb -ui"
 desc = "open with duckdb ui"
@@ -236,7 +236,7 @@ desc = "open with duckdb ui"
 Use with a larger preview window - add to your `yazi.toml`
 
 ```toml
-[manager]
+[mgr]
 ratio = [1, 2, 5]
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Once these are installed you can use the yazi plugin manager to install the plug
 Use the command:
 
 ```
-ya pack -a wylie102/duckdb
+ya pkg add wylie102/duckdb
 ```
 
 in your terminal
@@ -150,23 +150,24 @@ and add:
 ```toml
 [plugin]  
 prepend_previewers = [  
-  { name = "*.csv", run = "duckdb" },  
-  { name = "*.tsv", run = "duckdb" },  
-  { name = "*.json", run = "duckdb" },  
-  { name = "*.parquet", run = "duckdb" },  
-  { name = "*.txt", run = "duckdb" },  
-  { name = "*.xlsx", run = "duckdb" },  
-  { name = "*.db", run = "duckdb" },
-  { name = "*.duckdb", run = "duckdb" }
+  { url = "*.csv", run = "duckdb" },  
+  { url = "*.tsv", run = "duckdb" },  
+  { url = "*.json", run = "duckdb" },  
+  { url = "*.parquet", run = "duckdb" },  
+  { url = "*.txt", run = "duckdb" },  
+  { url = "*.xlsx", run = "duckdb" },  
+  { url = "*.db", run = "duckdb" },
+  { url = "*.duckdb", run = "duckdb" },
+  { mime = "application/x-parquet", run = "duckdb" }
 ]
 
 prepend_preloaders = [  
-  { name = "*.csv", run = "duckdb", multi = false },  
-  { name = "*.tsv", run = "duckdb", multi = false },  
-  { name = "*.json", run = "duckdb", multi = false },  
-  { name = "*.parquet", run = "duckdb", multi = false },
-  { name = "*.txt", run = "duckdb", multi = false },  
-  { name = "*.xlsx", run = "duckdb", multi = false }
+  { url = "*.csv", run = "duckdb", multi = false },  
+  { url = "*.tsv", run = "duckdb", multi = false },  
+  { url = "*.json", run = "duckdb", multi = false },  
+  { url = "*.parquet", run = "duckdb", multi = false },
+  { url = "*.txt", run = "duckdb", multi = false },  
+  { url = "*.xlsx", run = "duckdb", multi = false }
 ]
 ```
 


### PR DESCRIPTION
Updated command and plugin configuration for DuckDB matching changes in newer yazi versions.
Seems there are at least two open issues already related to this, so I thought it might be good to update the documentation.
Updated it to my working installation after also struggling for a while.