### PR TITLE
Use the new DuckDB lambda syntax to avoid the deprecation warning

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -423,7 +423,7 @@ set variable included_columns = (
 	)
 
 	local filtered_select = string.format(
-		"select %scolumns(c -> list_contains(getvariable('included_columns'), c)) from %s limit %d offset %d;",
+		"select %scolumns(lambda c : list_contains(getvariable('included_columns'), c)) from %s limit %d offset %d;",
 		row_id_prefix,
 		target,
 		limit,


### PR DESCRIPTION
Hi, and thanks for this plugin — it has been really nice to use.

While using it on Windows with Yazi 26.1.22 and DuckDB 1.5.0, I noticed DuckDB now emits this warning during preview:

`WARNING: Deprecated lambda arrow (->) detected`

This PR updates the remaining lambda expression in `main.lua` from the old arrow form to the current `lambda ... : ...` syntax:

- `c -> list_contains(...)`
- `lambda c : list_contains(...)`

As far as I can tell, this does not change behavior and just removes the warning on newer DuckDB versions.

If you'd prefer a different wording or style here, I'm happy to adjust it.